### PR TITLE
[#19] 투두 리스트 탭 캘린더 레이아웃 구현

### DIFF
--- a/OOTD/OOTD.xcodeproj/project.pbxproj
+++ b/OOTD/OOTD.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		BDB65B9028D0B5BC00679C02 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB65B8F28D0B5BC00679C02 /* Device.swift */; };
 		BDB65B9228D0B6B200679C02 /* PreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB65B9128D0B6B200679C02 /* PreviewProvider.swift */; };
 		BDB65B9428D0BE8100679C02 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB65B9328D0BE8100679C02 /* TabBarItem.swift */; };
+		BDB65B9628D1ADBE00679C02 /* TodoCalendarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB65B9528D1ADBE00679C02 /* TodoCalendarHeaderView.swift */; };
 		BDD8CA2A28CF1FD100668B70 /* OOTD_Core.h in Headers */ = {isa = PBXBuildFile; fileRef = BDD8CA2928CF1FD100668B70 /* OOTD_Core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BDD8CA2D28CF1FD100668B70 /* OOTD_Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD8CA2728CF1FD100668B70 /* OOTD_Core.framework */; };
 		BDD8CA2F28CF1FD100668B70 /* OOTD_Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BDD8CA2728CF1FD100668B70 /* OOTD_Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -158,6 +159,7 @@
 		BDB65B8F28D0B5BC00679C02 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		BDB65B9128D0B6B200679C02 /* PreviewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewProvider.swift; sourceTree = "<group>"; };
 		BDB65B9328D0BE8100679C02 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
+		BDB65B9528D1ADBE00679C02 /* TodoCalendarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCalendarHeaderView.swift; sourceTree = "<group>"; };
 		BDD8CA2728CF1FD100668B70 /* OOTD_Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OOTD_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDD8CA2928CF1FD100668B70 /* OOTD_Core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OOTD_Core.h; sourceTree = "<group>"; };
 		BDD8CA3728CF207000668B70 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 		BD9FA51028CF154D00E8D68B /* View */ = {
 			isa = PBXGroup;
 			children = (
+				BDB65B9528D1ADBE00679C02 /* TodoCalendarHeaderView.swift */,
 				BD9FA51128CF156800E8D68B /* TodoViewController.swift */,
 			);
 			path = View;
@@ -879,6 +882,7 @@
 				BD9FA4D328CF135100E8D68B /* AppDelegate.swift in Sources */,
 				BDB65B9428D0BE8100679C02 /* TabBarItem.swift in Sources */,
 				BD9FA51A28CF161B00E8D68B /* ProjectViewController.swift in Sources */,
+				BDB65B9628D1ADBE00679C02 /* TodoCalendarHeaderView.swift in Sources */,
 				BD9FA51828CF160E00E8D68B /* GitHubRegistrationViewController.swift in Sources */,
 				BD9FA51228CF156800E8D68B /* TodoViewController.swift in Sources */,
 				BD9FA51C28CF162500E8D68B /* SettingViewController.swift in Sources */,

--- a/OOTD/OOTD/Presentation/Todo/View/TodoCalendarHeaderView.swift
+++ b/OOTD/OOTD/Presentation/Todo/View/TodoCalendarHeaderView.swift
@@ -1,0 +1,103 @@
+//
+//  TodoCalendarHeaderView.swift
+//  OOTD
+//
+//  Created by taekki on 2022/09/14.
+//
+
+import UIKit
+
+import OOTD_Core
+import OOTD_UIKit
+
+final class TodoCalendarHeaderView: BaseView {
+    
+    private let dateLabel = UILabel()
+    private let commitDotView = UIView()
+    private let commitLabel = UILabel()
+    private let todoRateView = UIView()
+    private let todoRateLabel = UILabel()
+    
+    var date: String? {
+        didSet { dateTitle = date }
+    }
+    
+    var commitCount: Int = 0 {
+        didSet { commitTitle = "\(commitCount) 커밋" }
+    }
+    
+    var todoPercent: Int = 0 {
+        didSet { todoTitle = "투두 \(todoPercent)% 달성" }
+    }
+    
+    private var dateTitle: String? {
+        get { dateLabel.text }
+        set { dateLabel.text = newValue }
+    }
+    
+    private var commitTitle: String? {
+        get { commitLabel.text }
+        set { commitLabel.text = newValue }
+    }
+    
+    private var todoTitle: String? {
+        get { todoRateLabel.text }
+        set { todoRateLabel.text = newValue }
+    }
+    
+    override func configureAttributes() {
+        dateLabel.do {
+            $0.font = .ootdFont(.bold, size: 24)
+            $0.textColor = .grey900
+        }
+        
+        commitDotView.do {
+            $0.backgroundColor = .green800
+        }
+        
+        commitLabel.do {
+            $0.font = .ootdFont(.medium, size: 10)
+            $0.textColor = .grey700
+        }
+        
+        todoRateView.do {
+            $0.backgroundColor = .yellow800
+        }
+        
+        todoRateLabel.do {
+            $0.font = .ootdFont(.medium, size: 10)
+            $0.textColor = .grey700
+        }
+    }
+    
+    override func configureLayout() {
+        addSubviews(dateLabel, commitDotView, commitLabel, todoRateView, todoRateLabel)
+        
+        dateLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(Spacing.s8)
+            $0.leading.equalToSuperview().inset(Spacing.s20)
+        }
+        
+        commitDotView.snp.makeConstraints {
+            $0.top.equalTo(dateLabel.snp.bottom).offset(Spacing.s8)
+            $0.leading.equalToSuperview().inset(Spacing.s20)
+            $0.size.equalTo(8)
+        }
+        
+        commitLabel.snp.makeConstraints {
+            $0.centerY.equalTo(commitDotView.snp.centerY)
+            $0.leading.equalTo(commitDotView.snp.trailing).offset(Spacing.s4)
+        }
+        
+        todoRateView.snp.makeConstraints {
+            $0.centerY.equalTo(commitDotView.snp.centerY)
+            $0.leading.equalTo(commitLabel.snp.trailing).offset(Spacing.s8)
+            $0.size.equalTo(8)
+        }
+        
+        todoRateLabel.snp.makeConstraints {
+            $0.centerY.equalTo(commitDotView.snp.centerY)
+            $0.leading.equalTo(todoRateView.snp.trailing).offset(Spacing.s4)
+        }
+    }
+}

--- a/OOTD/OOTD/Presentation/Todo/View/TodoViewController.swift
+++ b/OOTD/OOTD/Presentation/Todo/View/TodoViewController.swift
@@ -88,7 +88,7 @@ extension TodoViewController {
     }
 }
 
-extension TodoViewController: FSCalendarDelegate, FSCalendarDataSource {
+extension TodoViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
 
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         self.date = date
@@ -98,4 +98,31 @@ extension TodoViewController: FSCalendarDelegate, FSCalendarDataSource {
         date = calendar.currentPage
         calendar.select(date)
     }
+    
+    func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
+        return 2
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, eventSelectionColorsFor date: Date) -> [UIColor]? {
+        return [.green800, .yellow800]
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, eventDefaultColorsFor date: Date) -> [UIColor]? {
+        let commitColor: UIColor = [UIColor.green800, UIColor.green600].randomElement()!.withAlphaComponent(0.5 * CGFloat.random(in: 1...2))
+        let yellowColor: UIColor = [UIColor.yellow800, UIColor.yellow600].randomElement()!.withAlphaComponent(0.5 * CGFloat.random(in: 1...2))
+        
+        return [commitColor, yellowColor]
+    }
 }
+
+// MARK: - Preview
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct Preview: PreviewProvider {
+    static var previews: some View {
+        TabBarController().showPreview(.iPhone13Mini)
+    }
+}
+#endif

--- a/OOTD/OOTD/Presentation/Todo/View/TodoViewController.swift
+++ b/OOTD/OOTD/Presentation/Todo/View/TodoViewController.swift
@@ -38,7 +38,7 @@ final class TodoViewController: BaseViewController {
         configureCalendarView()
         
         dateFormatter.do {
-            $0.dateFormat = "YYYY년 M월"
+            $0.dateFormat = "YYYY년 M월 d일"
             $0.locale = Locale(identifier: "ko_KR")
             $0.timeZone = TimeZone(identifier: "ko_KR")
         }
@@ -69,6 +69,9 @@ final class TodoViewController: BaseViewController {
 extension TodoViewController {
     
     private func configureCalendarView() {
+        calendarView.delegate = self
+        calendarView.dataSource = self
+        
         calendarView.select(Date())
         calendarView.headerHeight = 0
         calendarView.firstWeekday = 2
@@ -82,5 +85,17 @@ extension TodoViewController {
         calendarView.appearance.weekdayFont = .ootdFont(.regular, size: 10)
         calendarView.appearance.titleFont = .ootdFont(.medium, size: 14)
         calendarView.appearance.selectionColor = .clear
+    }
+}
+
+extension TodoViewController: FSCalendarDelegate, FSCalendarDataSource {
+
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        self.date = date
+    }
+    
+    func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+        date = calendar.currentPage
+        calendar.select(date)
     }
 }

--- a/OOTD/OOTD/Presentation/Todo/View/TodoViewController.swift
+++ b/OOTD/OOTD/Presentation/Todo/View/TodoViewController.swift
@@ -7,15 +7,80 @@
 
 import UIKit
 
+import FSCalendar
 import OOTD_Core
+import OOTD_UIKit
 
 final class TodoViewController: BaseViewController {
     
+    lazy var headerView = TodoCalendarHeaderView()
+    let calendarView = FSCalendar()
+    
+    private let dateFormatter = DateFormatter()
+    
+    private var date = Date() {
+        didSet { headerView.date = dateFormatter.string(from: date) }
+    }
+    
+    private var commitCount = 0 {
+        didSet { headerView.commitCount = commitCount }
+    }
+    
+    private var todoPercent = 0 {
+        didSet { headerView.todoPercent = todoPercent }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func configureAttributes() {
+        configureCalendarView()
+        
+        dateFormatter.do {
+            $0.dateFormat = "YYYY년 M월"
+            $0.locale = Locale(identifier: "ko_KR")
+            $0.timeZone = TimeZone(identifier: "ko_KR")
+        }
+        
+        headerView.do {
+            $0.date = dateFormatter.string(from: date)
+            $0.commitCount = commitCount
+            $0.todoPercent = todoPercent
+        }
+    }
+    
+    override func configureLayout() {
+        view.addSubviews(headerView, calendarView)
+        
+        headerView.snp.makeConstraints {
+            $0.top.directionalHorizontalEdges.equalToSuperview()
+            $0.height.equalTo(70)
+        }
+        
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(Spacing.s8)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(Spacing.s16)
+            $0.height.equalTo(280.adjustedHeight)
+        }
     }
 }
 
 extension TodoViewController {
     
+    private func configureCalendarView() {
+        calendarView.select(Date())
+        calendarView.headerHeight = 0
+        calendarView.firstWeekday = 2
+        calendarView.placeholderType = .fillHeadTail
+        calendarView.locale = Locale(identifier: "ko_KR")
+        calendarView.appearance.weekdayTextColor = .grey700
+        calendarView.appearance.titleDefaultColor = .grey700
+        calendarView.appearance.titleTodayColor = .grey700
+        calendarView.appearance.titleSelectionColor = .yellow800
+        calendarView.appearance.todayColor = .clear
+        calendarView.appearance.weekdayFont = .ootdFont(.regular, size: 10)
+        calendarView.appearance.titleFont = .ootdFont(.medium, size: 14)
+        calendarView.appearance.selectionColor = .clear
+    }
 }


### PR DESCRIPTION
## 🌱 PR 요약

> 구현 내용 및 작업 내역

- [x] TodoCalendarHeaderView 구현
- [x] 투두 리스트 탭 캘린더 레이아웃 구현
- [x] 날짜 선택 시에 headerView 텍스트 변경
- [x] 캘린더 Event dot 컬러 테스트
  - 커밋 수/투두 퍼센티지에 따른 컬러 디테일을 어떻게 처리할 지 정해야 됩니다.
  - ex. 투두 25% - 연노랑

## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

## 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 사용자 가이드 업데이트가 필요한가?
  - [ ] 사용자 가이드를 업데이트 하였는가?
  
## 📸 스크린샷

|스크린샷|설명|
|:--:|:--:|
|투두 리스트 탭 캘린더 뷰 레이아웃|<img src = "https://user-images.githubusercontent.com/61109660/190145901-41c03683-5f0e-4348-a42c-bc8efcaf47cb.png" width = "300"/>|

## 📮 관련 이슈

Resolved: #19
