### PR TITLE
[#42] 깃허브 닉네임 등록 레이아웃 구현

### DIFF
--- a/OOTD/OOTD/Presentation/GitHub/View/GitHubRegistrationViewController.swift
+++ b/OOTD/OOTD/Presentation/GitHub/View/GitHubRegistrationViewController.swift
@@ -5,4 +5,78 @@
 //  Created by taekki on 2022/09/12.
 //
 
-import Foundation
+import UIKit
+
+import FSCalendar
+import OOTD_Core
+import OOTD_UIKit
+
+final class GitHubRegistrationViewController: BaseViewController {
+    
+    private let messageLabel = UILabel()
+    private let gitHubNicknameTextField = ODSTextField()
+    private lazy var buttonVStackView = UIStackView(arrangedSubviews: [confirmButton, registrationButton])
+    private let confirmButton = ODSButton(.disabled)
+    private let registrationButton = ODSButton(.sub)
+    
+    override func configureAttributes() {
+        messageLabel.do {
+            $0.text = """
+            커밋 기록을 확인하기 위해
+            GitHub 닉네임을 등록해보세요.
+            """
+            $0.textColor = .grey900
+            $0.textAlignment = .center
+            $0.font = .ootdFont(.bold, size: 24)
+            $0.numberOfLines = 0
+        }
+        
+        gitHubNicknameTextField.do {
+            $0.font = UIFont.systemFont(ofSize: 14)
+            $0.placeholder = "본인의 GitHub 계정을 정확하게 입력해주세요."
+        }
+        
+        buttonVStackView.do {
+            $0.axis = .vertical
+            $0.distribution = .fillEqually
+            $0.spacing = Spacing.s4
+        }
+        
+        confirmButton.do {
+            $0.title = "완료"
+        }
+        
+        registrationButton.do {
+            $0.title = "다음에 등록하기"
+        }
+    }
+    
+    override func configureLayout() {
+        view.addSubviews(messageLabel, gitHubNicknameTextField, buttonVStackView)
+        
+        messageLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(60)
+            $0.centerX.equalToSuperview()
+        }
+        
+        gitHubNicknameTextField.snp.makeConstraints {
+            $0.top.equalTo(messageLabel.snp.bottom).offset(30)
+            $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(Spacing.s20)
+            $0.height.equalTo(40)
+        }
+        
+        buttonVStackView.snp.makeConstraints {
+            $0.top.equalTo(gitHubNicknameTextField.snp.bottom).offset(24)
+            $0.directionalHorizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(Spacing.s20)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.height.equalTo(48)
+        }
+        
+        registrationButton.snp.makeConstraints {
+            $0.height.equalTo(48)
+        }
+    }
+}
+


### PR DESCRIPTION
## 🌱 PR 요약

> 구현 내용 및 작업 내역

- [x] 깃허브 닉네임 등록 레이아웃 구현

## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

## 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 사용자 가이드 업데이트가 필요한가?
  - [ ] 사용자 가이드를 업데이트 하였는가?
  
## 📸 스크린샷

|스크린샷|설명|
|:--:|:--:|
|깃허브 닉네임 등록 뷰| <img src = "https://user-images.githubusercontent.com/61109660/191524065-37dc20d2-ccf9-4327-8f4d-64bac6e0e4de.png" width = 300 />

## 📮 관련 이슈

Resolved: #42 
