### PR TITLE
[#49] 프로젝트 탭 작성 뷰 태그 필드 레이아웃 구현

### DIFF
--- a/OOTD/OOTD.xcodeproj/project.pbxproj
+++ b/OOTD/OOTD.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		BDB65B9228D0B6B200679C02 /* PreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB65B9128D0B6B200679C02 /* PreviewProvider.swift */; };
 		BDB65B9428D0BE8100679C02 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB65B9328D0BE8100679C02 /* TabBarItem.swift */; };
 		BDB65B9628D1ADBE00679C02 /* TodoListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB65B9528D1ADBE00679C02 /* TodoListHeaderView.swift */; };
+		BDD5F8B528DD9B1D003F3B03 /* WSTagsField in Frameworks */ = {isa = PBXBuildFile; productRef = BDD5F8B428DD9B1D003F3B03 /* WSTagsField */; };
+		BDD5F8B728DD9E81003F3B03 /* TagFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD5F8B628DD9E81003F3B03 /* TagFieldCell.swift */; };
 		BDD8CA2A28CF1FD100668B70 /* OOTD_Core.h in Headers */ = {isa = PBXBuildFile; fileRef = BDD8CA2928CF1FD100668B70 /* OOTD_Core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BDD8CA2D28CF1FD100668B70 /* OOTD_Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD8CA2728CF1FD100668B70 /* OOTD_Core.framework */; };
 		BDD8CA2F28CF1FD100668B70 /* OOTD_Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BDD8CA2728CF1FD100668B70 /* OOTD_Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -228,6 +230,7 @@
 		BDB65B9128D0B6B200679C02 /* PreviewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewProvider.swift; sourceTree = "<group>"; };
 		BDB65B9328D0BE8100679C02 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		BDB65B9528D1ADBE00679C02 /* TodoListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListHeaderView.swift; sourceTree = "<group>"; };
+		BDD5F8B628DD9E81003F3B03 /* TagFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagFieldCell.swift; sourceTree = "<group>"; };
 		BDD8CA2728CF1FD100668B70 /* OOTD_Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OOTD_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDD8CA2928CF1FD100668B70 /* OOTD_Core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OOTD_Core.h; sourceTree = "<group>"; };
 		BDD8CA3728CF207000668B70 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
@@ -263,6 +266,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDD5F8B528DD9B1D003F3B03 /* WSTagsField in Frameworks */,
 				BD9FA52828CF171600E8D68B /* SnapKit in Frameworks */,
 				BD9FA52E28CF17AB00E8D68B /* FSCalendar in Frameworks */,
 				BDD8CA5728CF30EC00668B70 /* OOTD_UIKit.framework in Frameworks */,
@@ -361,11 +365,12 @@
 		BD621A3128DC3A5F008CFBB8 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				BD19C4CC28DC4E6500D209A1 /* LogoCell.swift */,
+				BD19C4CA28DC4E1800D209A1 /* MemoCell.swift */,
+				BD19C4CE28DC569800D209A1 /* PeriodCell.swift */,
 				BD621A3228DC3A6E008CFBB8 /* ProjectArchiveView.swift */,
 				BD621A2E28DC39DC008CFBB8 /* ProjectArchiveViewController.swift */,
-				BD19C4CA28DC4E1800D209A1 /* MemoCell.swift */,
-				BD19C4CC28DC4E6500D209A1 /* LogoCell.swift */,
-				BD19C4CE28DC569800D209A1 /* PeriodCell.swift */,
+				BDD5F8B628DD9E81003F3B03 /* TagFieldCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -879,6 +884,7 @@
 				BD9FA52D28CF17AB00E8D68B /* FSCalendar */,
 				BD9FA53028CF180C00E8D68B /* Realm */,
 				BD9FA53228CF180C00E8D68B /* RealmSwift */,
+				BDD5F8B428DD9B1D003F3B03 /* WSTagsField */,
 			);
 			productName = OOTD;
 			productReference = BD9FA4CF28CF135100E8D68B /* OOTD.app */;
@@ -1007,6 +1013,7 @@
 				BD9FA52928CF174B00E8D68B /* XCRemoteSwiftPackageReference "Then" */,
 				BD9FA52C28CF17AB00E8D68B /* XCRemoteSwiftPackageReference "FSCalendar" */,
 				BD9FA52F28CF180C00E8D68B /* XCRemoteSwiftPackageReference "realm-swift" */,
+				BDD5F8B328DD9B1D003F3B03 /* XCRemoteSwiftPackageReference "WSTagsField" */,
 			);
 			productRefGroup = BD9FA4D028CF135100E8D68B /* Products */;
 			projectDirPath = "";
@@ -1123,6 +1130,7 @@
 				BDDAB6DF28D2142400C021BC /* TodoCell.swift in Sources */,
 				BD8B408D28D46C7100A4E810 /* InputCell.swift in Sources */,
 				BD8B408828D4558E00A4E810 /* PriorityCell.swift in Sources */,
+				BDD5F8B728DD9E81003F3B03 /* TagFieldCell.swift in Sources */,
 				BD70EB1728D9890C0063DE18 /* TodoListCollectionViewAdapter.swift in Sources */,
 				BD19C4CB28DC4E1800D209A1 /* MemoCell.swift in Sources */,
 				BD70EB0728D8AB4D0063DE18 /* Repository.swift in Sources */,
@@ -1711,6 +1719,14 @@
 				minimumVersion = 10.0.0;
 			};
 		};
+		BDD5F8B328DD9B1D003F3B03 /* XCRemoteSwiftPackageReference "WSTagsField" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/whitesmith/WSTagsField.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1738,6 +1754,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BD9FA52F28CF180C00E8D68B /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;
+		};
+		BDD5F8B428DD9B1D003F3B03 /* WSTagsField */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BDD5F8B328DD9B1D003F3B03 /* XCRemoteSwiftPackageReference "WSTagsField" */;
+			productName = WSTagsField;
 		};
 		BDD8CABF28CF7DB500668B70 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/OOTD/OOTD.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OOTD/OOTD.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -44,6 +44,15 @@
         "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
         "version" : "3.0.0"
       }
+    },
+    {
+      "identity" : "wstagsfield",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/whitesmith/WSTagsField.git",
+      "state" : {
+        "revision" : "4a3f36d1903554bb6b65df0e7936df9bb95d7525",
+        "version" : "5.4.0"
+      }
     }
   ],
   "version" : 2

--- a/OOTD/OOTD/Presentation/Project Archive/Helper/ProjectArchiveSection.swift
+++ b/OOTD/OOTD/Presentation/Project Archive/Helper/ProjectArchiveSection.swift
@@ -44,6 +44,11 @@ extension ProjectArchiveSection {
                 widthDimension: .fractionalWidth(1),
                 heightDimension: .estimated(175)
             )
+        case .member, .tech:
+            return NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(48)
+            )
         default:
             return NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
@@ -59,10 +64,15 @@ extension ProjectArchiveSection {
                 widthDimension: .estimated(64),
                 heightDimension: .estimated(64)
             )
-        case .name, .desc, .gitHubLink, .member, .period, .tech:
+        case .name, .desc, .gitHubLink, .period:
             return NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1),
                 heightDimension: .estimated(44)
+            )
+        case .member, .tech:
+            return NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(48)
             )
         case .memo:
             return NSCollectionLayoutSize(

--- a/OOTD/OOTD/Presentation/Project Archive/View/ProjectArchiveViewController.swift
+++ b/OOTD/OOTD/Presentation/Project Archive/View/ProjectArchiveViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import OOTD_Core
 import OOTD_UIKit
 
-final class ProjectArchiveViewController: BaseViewController, ProjectArchiveCollectionViewAdapterDelegate {
+final class ProjectArchiveViewController: BaseViewController {
     
     private let viewModel = ProjectArchiveViewModel()
     private lazy var adapter: ProjectArchiveCollectionViewAdapter = {
@@ -43,5 +43,12 @@ extension ProjectArchiveViewController {
     
     @objc private func popViewController() {
         navigationController?.popViewController(animated: true)
+    }
+}
+
+extension ProjectArchiveViewController: ProjectArchiveCollectionViewAdapterDelegate {
+    
+    func reload() {
+        rootView.collectionView.collectionViewLayout.invalidateLayout()
     }
 }

--- a/OOTD/OOTD/Presentation/Project Archive/View/TagFieldCell.swift
+++ b/OOTD/OOTD/Presentation/Project Archive/View/TagFieldCell.swift
@@ -1,0 +1,54 @@
+//
+//  TagFieldCell.swift
+//  OOTD
+//
+//  Created by taekki on 2022/09/23.
+//
+
+import UIKit
+
+import OOTD_Core
+import OOTD_UIKit
+import WSTagsField
+
+final class TagFieldCell: BaseCollectionViewCell {
+    
+    lazy var tagField = WSTagsField()
+    
+    override func configureAttributes() {
+        super.configureAttributes()
+        
+        tagField.do {
+            $0.makeRounded(radius: 4)
+            $0.layer.borderWidth = 2
+            $0.layer.borderColor = UIColor.grey500.cgColor
+            $0.layoutMargins = UIEdgeInsets(top: 2, left: 6, bottom: 2, right: 6)
+            $0.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+            $0.spaceBetweenLines = 10
+            $0.spaceBetweenTags = 4
+            $0.backgroundColor = .white
+            $0.tintColor = .grey800
+            $0.selectedColor = .yellow800
+            $0.selectedTextColor = .white
+            $0.placeholderAlwaysVisible = true
+            $0.font = .systemFont(ofSize: 14)
+        }
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        contentView.addSubview(tagField)
+        
+        tagField.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension TagFieldCell {
+    
+    func configure(_ section: ProjectArchiveSection? = .member) {
+        tagField.placeholder = section == .member ? "ex. 멤버" : "ex. Swift"
+    }
+}

--- a/OOTD/OOTD/Presentation/TodoBottomSheet/View/InputCell.swift
+++ b/OOTD/OOTD/Presentation/TodoBottomSheet/View/InputCell.swift
@@ -22,6 +22,7 @@ final class InputCell: BaseCollectionViewCell {
         backgroundColor = .clear
         
         textField.do {
+            $0.font = .systemFont(ofSize: 14)
             $0.addTarget(self, action: #selector(self.textFieldDidChange), for: .editingChanged)
         }
     }


### PR DESCRIPTION
- WSTagsField 라이브러리 이용

## 🌱 PR 요약

> 구현 내용 및 작업 내역

- [x]  프로젝트 탭 작성 뷰 태그 필드 레이아웃 구현
  - [x] WSTagsField 라이브러리 의존성 추가

## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

## 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 사용자 가이드 업데이트가 필요한가?
  - [ ] 사용자 가이드를 업데이트 하였는가?
  
## 📸 스크린샷

|스크린샷|설명|
|:--:|:--:|
|팀원 필드 · 기술 필드|![Simulator Screen Recording - iPhone 13 mini - 2022-09-23 at 23 08 23](https://user-images.githubusercontent.com/61109660/191979654-0cc9e350-d874-40ce-9aa8-d2d91aecfc14.gif)|

## 📮 관련 이슈

Resolved: #49 
